### PR TITLE
feat: Implement NewsItem composable and integrate into HomeScreen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,3 @@
-
 import java.util.Properties
 
 plugins {

--- a/app/src/main/java/com/example/mealmate/ui/view/components/NewsItem/FullScreenImageView.kt
+++ b/app/src/main/java/com/example/mealmate/ui/view/components/NewsItem/FullScreenImageView.kt
@@ -1,0 +1,68 @@
+package com.example.mealmate.ui.view.components.NewsItem
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FullScreenImageView(
+    imageUrl: String,
+    onDismiss: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Aperçu de l'image") },
+                navigationIcon = {
+                    IconButton(onClick = onDismiss) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Retour"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(3.dp), // Couleur de fond pour la top bar
+                    titleContentColor = MaterialTheme.colorScheme.onSurface,
+                    navigationIconContentColor = MaterialTheme.colorScheme.onSurface
+                )
+            )
+        },
+        containerColor = Color.Black.copy(alpha = 0.8f) // Fond semi-transparent pour l'effet "lightbox"
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .clickable(onClick = onDismiss), // Permet de fermer en cliquant sur l'image/fond
+            contentAlignment = Alignment.Center
+        ) {
+            AsyncImage(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(imageUrl)
+                    .crossfade(true)
+                    .listener(onError = { _, _ -> onDismiss() }) // Si l'image ne peut pas se charger en plein écran, ferme le dialogue
+                    .build(),
+                contentDescription = "Image en plein écran",
+                contentScale = ContentScale.Fit,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp) // Un peu de padding autour de l'image en plein écran
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/mealmate/ui/view/components/NewsItem/NewsData.kt
+++ b/app/src/main/java/com/example/mealmate/ui/view/components/NewsItem/NewsData.kt
@@ -1,0 +1,9 @@
+package com.example.mealmate.ui.view.components.NewsItem
+
+data class NewsData(
+    val title: String,
+    val authorName: String,
+    val link: String?,
+    val partnerImageUrl: String?,
+    val newImageUrl: String?
+)

--- a/app/src/main/java/com/example/mealmate/ui/view/components/NewsItem/NewsItem.kt
+++ b/app/src/main/java/com/example/mealmate/ui/view/components/NewsItem/NewsItem.kt
@@ -1,0 +1,177 @@
+package com.example.mealmate.ui.view.components.NewsItem
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import coil.compose.AsyncImage
+import com.example.mealmate.ui.view.components.bottomSheet.NewsItemBtmSheet
+import com.example.mealmate.R
+
+@Composable
+fun NewsItem(
+    title: String,
+    authorName: String,
+    link: String?,
+    partnerImageUrl: String?,
+    newImageUrl: String?,
+    contenair: Color = MaterialTheme.colorScheme.background,
+    content: Color = MaterialTheme.colorScheme.onBackground,
+    modifier: Modifier = Modifier.height(350.dp)
+) {
+    var showMoreVert by remember { mutableStateOf(false) }
+    var showFullScreenImage by remember { mutableStateOf<String?>(null) }
+
+    Card(
+        modifier = modifier,
+        elevation = CardDefaults.elevatedCardElevation(4.dp),
+        shape = RoundedCornerShape(8.dp),
+        //colors = CardDefaults.cardColors(containerColor = contenair) // Définir la couleur du conteneur ici
+    ){
+        Column(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            Box(modifier = Modifier
+                .weight(0.8f)
+                .clickable { newImageUrl?.let { link -> showFullScreenImage = link } }){
+                AsyncImage(
+                    model = newImageUrl,
+                    contentDescription = null,
+                    placeholder = painterResource(R.drawable.ic_launcher_background),
+                    error = painterResource(R.drawable.ic_launcher_background),
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+
+            Row (
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 5.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            ){
+                Spacer(modifier = Modifier.width(0.dp))
+                AsyncImage(
+                    model = partnerImageUrl,
+                    contentDescription = null,
+                    placeholder = painterResource(R.drawable.nouser_profilepicture),
+                    error = painterResource(R.drawable.nouser_profilepicture),
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .clip(CircleShape)
+                        .size(40.dp)
+                )
+
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        color = content
+                    ),
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
+                )
+
+                IconButton(
+                    onClick = {showMoreVert = !showMoreVert},
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.MoreVert,
+                        contentDescription = "moreVert"
+                    )
+                }
+            }
+
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 60.dp, vertical = 5.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ){
+                Icon(
+                    painter = painterResource(R.drawable.verified_filled_icn),
+                    contentDescription = "Verified Entity",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(16.dp)
+                )
+                Spacer(modifier = Modifier.width(10.dp))
+                Text(
+                    text = authorName,
+                    style = MaterialTheme.typography.labelMedium.copy(
+                        fontStyle = FontStyle.Italic,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    ),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+
+        showFullScreenImage?.let { imageUrl ->
+            Dialog(
+                onDismissRequest = { showFullScreenImage = null },
+                properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false) // Pour un vrai plein écran
+            ) {
+                FullScreenImageView(
+                    imageUrl = imageUrl,
+                    onDismiss = { showFullScreenImage = null }
+                )
+            }
+        }
+
+        if (showMoreVert){
+            NewsItemBtmSheet(
+                link = link,
+                isVisible = showMoreVert,
+                onDismiss = { showMoreVert = false}
+            )
+        }
+    }
+
+}
+
+@Preview(showBackground = true)
+@Composable
+fun NewsImagePrevv(modifier: Modifier = Modifier) {
+    NewsItem(
+        title = "Nouvelle campagne de vaccination pour les diabetiques au centre pasteur !!!",
+        authorName = "Ministere de la sante publique",
+        link = null,
+        partnerImageUrl = null,
+        newImageUrl = null,
+        modifier = Modifier.height(300.dp)
+    )
+
+}

--- a/app/src/main/java/com/example/mealmate/ui/view/components/bottomSheet/NewsItemBtmSheet.kt
+++ b/app/src/main/java/com/example/mealmate/ui/view/components/bottomSheet/NewsItemBtmSheet.kt
@@ -1,0 +1,109 @@
+package com.example.mealmate.ui.view.components.bottomSheet
+
+
+import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.example.mealmate.ui.view.components.rowIconText.RowContent
+import com.example.mealmate.ui.view.components.rowIconText.RowContentItem
+import kotlin.collections.forEachIndexed
+import com.example.mealmate.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NewsItemBtmSheet(
+    link: String?,
+    isVisible: Boolean,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    val sheetState = rememberModalBottomSheetState( skipPartiallyExpanded = true )
+    val listRowContent = listOf(
+        RowContentItem(
+            value = "Lire sur le site officiel", //dans le navigateur
+            icon = R.drawable.outward_arrow_icn,
+            onClick = { item->
+                link?.let { url->
+                    try {
+                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                    }catch (e: Exception){
+                        Toast.makeText(context, "Erreur lors de l'ouverture du lien", Toast.LENGTH_SHORT).show()
+                    }
+                } ?: run {
+                    Toast.makeText(context, "Lien non disponible", Toast.LENGTH_SHORT).show()
+                }
+                onDismiss()
+            },
+        )
+    )
+
+    if (isVisible){
+        ModalBottomSheet(
+            onDismissRequest = { onDismiss() },
+            sheetState = sheetState,
+            tonalElevation = 4.dp,
+            dragHandle = {
+                Box(
+                    modifier = Modifier
+                        .padding(top = 16.dp, bottom = 8.dp)
+                        .width(40.dp)
+                        .height(4.dp)
+                        .background(Color.Gray, CircleShape)
+                )
+            },
+        ){
+            ContenairMorvertem(listRowContent = listRowContent)
+        }
+    }
+}
+
+@Composable
+fun ContenairMorvertem(
+    listRowContent: List<RowContentItem>,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(vertical = 8.dp)
+) {
+    Box( modifier = modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 8.dp) ){
+        Column(
+            modifier = Modifier.padding(contentPadding),
+            horizontalAlignment = Alignment.Start,
+            //verticalArrangement = Arrangement.Center,
+            //horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            listRowContent.forEachIndexed { index, item ->
+                RowContent(item = item)
+
+                // Ajout d'un Divider entre les éléments sauf pour le dernier
+                if (index < listRowContent.lastIndex) {
+                    Divider(
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        thickness = 1.dp,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/mealmate/ui/view/components/rowIconText/RowContentItem.kt
+++ b/app/src/main/java/com/example/mealmate/ui/view/components/rowIconText/RowContentItem.kt
@@ -16,8 +16,8 @@ data class RowContentItem(
     val value: String,
     @DrawableRes val icon: Int,
     val keyboardType: KeyboardType = KeyboardType.Text,
-    val onClick: (RowContentItem) -> Unit, // Modifier le type de onClick
-    val onLongClick: ((RowContentItem) -> Unit)? = null // Ajouter une option pour un long clic
+    val onClick: (RowContentItem) -> Unit,
+    val onLongClick: ((RowContentItem) -> Unit)? = null // option pour un long clic
 )
 
 

--- a/app/src/main/java/com/example/mealmate/ui/view/components/vibration/ShortVibration.kt
+++ b/app/src/main/java/com/example/mealmate/ui/view/components/vibration/ShortVibration.kt
@@ -1,0 +1,25 @@
+package com.example.mealmate.ui.view.components.vibration
+
+import android.content.Context
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun ShortVibration(
+    context: Context,
+) {
+    val vibrator = context.getSystemService(Vibrator::class.java)
+
+    //verifions si la vibration est disponible sur le device
+    if(vibrator.hasVibrator()){
+        // Créer un VibrationEffect selon la version d'Android
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O){
+            vibrator.vibrate(VibrationEffect.createOneShot(50, VibrationEffect.DEFAULT_AMPLITUDE))
+        }else{
+            vibrator.vibrate(50)
+        }
+    }
+}

--- a/app/src/main/java/com/example/mealmate/ui/view/dashboardScreen/DashboardScreen.kt
+++ b/app/src/main/java/com/example/mealmate/ui/view/dashboardScreen/DashboardScreen.kt
@@ -55,8 +55,6 @@ fun DashboardScreen(
                         maxWidth > 600.dp -> 2//tablette
                         else -> 1//smartphone
                     }
-
-
                 }
             }
         }

--- a/app/src/main/java/com/example/mealmate/ui/view/homeScreen/HomeScreen.kt
+++ b/app/src/main/java/com/example/mealmate/ui/view/homeScreen/HomeScreen.kt
@@ -4,10 +4,15 @@ import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -16,6 +21,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.example.mealmate.data.source.model.User
+import com.example.mealmate.ui.view.components.NewsItem.NewsData
+import com.example.mealmate.ui.view.components.NewsItem.NewsItem
 import com.example.mealmate.ui.view.components.myBottomAppBar.MyBottomAppBar
 import com.example.mealmate.ui.view.components.myBottomAppBar.MyNavigationOnRail
 import com.example.mealmate.ui.view.components.myTopAppBar.MyTopBar
@@ -27,10 +34,68 @@ fun HomeScreen(
     currentUser: User? = null
 ) {
     val user = currentUser ?: return
+    val news = listOf(
+        NewsData(
+            title = "Nouvelle campagne de vaccination pour les diabetiques au centre pasteur !!!",
+            authorName = "Ministere de la sante publique",
+            link = null,
+            partnerImageUrl = null,
+            newImageUrl = null,
+        ),
+        NewsData(
+            title = "Nouvelle campagne de vaccination pour les diabetiques au centre pasteur !!!",
+            authorName = "Ministere de la sante publique",
+            link = null,
+            partnerImageUrl = null,
+            newImageUrl = null,
+        ),
+        NewsData(
+            title = "Nouvelle campagne de vaccination pour les diabetiques au centre pasteur !!!",
+            authorName = "Ministere de la sante publique",
+            link = null,
+            partnerImageUrl = null,
+            newImageUrl = null,
+        ),
+        NewsData(
+            title = "Nouvelle campagne de vaccination pour les diabetiques au centre pasteur !!!",
+            authorName = "Ministere de la sante publique",
+            link = null,
+            partnerImageUrl = null,
+            newImageUrl = null,
+        ),
+        NewsData(
+            title = "Nouvelle campagne de vaccination pour les diabetiques au centre pasteur !!!",
+            authorName = "Ministere de la sante publique",
+            link = null,
+            partnerImageUrl = null,
+            newImageUrl = null,
+        ),
+        NewsData(
+            title = "Nouvelle campagne de vaccination pour les diabetiques au centre pasteur !!!",
+            authorName = "Ministere de la sante publique",
+            link = null,
+            partnerImageUrl = null,
+            newImageUrl = null,
+        ),
+
+//        NewsItem(
+//            title = "Nouvelle campagne de vaccination pour les diabetiques au centre pasteur !!!",
+//            authorName = "Ministere de la sante publique",
+//            link = null,
+//            partnerImageUrl = null,
+//            newImageUrl = null,
+//            modifier = Modifier.height(300.dp)
+//        )
+    )
 
     BoxWithConstraints(modifier = Modifier.fillMaxSize()){
+        val maxWidth = maxWidth
         if(maxWidth > 600.dp){
             Row(modifier = Modifier.fillMaxSize()){
+                val columnCount = when {
+                    maxWidth > 1200.dp -> 4
+                    else -> 2
+                }
                 MyNavigationOnRail(navController = navController)
                 //other things
                 MyTopBar(
@@ -39,10 +104,17 @@ fun HomeScreen(
                     onNotificationClick = { /*--Rien pour le moment--*/ },
                     onSearchClick = { /*--Rien pour le moment--*/  }
                 )
-                Spacer(modifier = Modifier.weight(1f))
+
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(columnCount),
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ){
+                    //
+                }
             }
         }else{
-
             Scaffold(
                 topBar = {
                     MyTopBar(
@@ -56,15 +128,22 @@ fun HomeScreen(
                     MyBottomAppBar(navController = navController)
                 },
             ) { paddingValues ->
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(paddingValues)
-                    ,
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(1),
+                    modifier = Modifier.fillMaxSize().padding(paddingValues),
+                    contentPadding = PaddingValues(10.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp)
                 ){
-                    Text(text = "Bonjour ${user.email} comment vas tu ?",)
+                    items(news) { news->
+                        NewsItem(
+                            title = news.title,
+                            authorName = news.authorName,
+                            link = news.link,
+                            partnerImageUrl = news.partnerImageUrl,
+                            newImageUrl = news.newImageUrl,
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/mealmate/ui/view/settingsScreen/SettingsScreen.kt
+++ b/app/src/main/java/com/example/mealmate/ui/view/settingsScreen/SettingsScreen.kt
@@ -22,7 +22,7 @@ import com.example.mealmate.data.source.model.User
 import com.example.mealmate.ui.view.components.myBottomAppBar.MyBottomAppBar
 import com.example.mealmate.ui.view.components.myBottomAppBar.MyNavigationOnRail
 import com.example.mealmate.ui.view.components.myTopAppBar.MyTopBar
-import com.example.mealmate.ui.view.settingsScreen.components.CardContent
+import com.example.mealmate.ui.view.settingsScreen.components.ContenairSettingsItems
 import com.example.mealmate.ui.view.components.rowIconText.RowContentItem
 
 @SuppressLint("UnusedBoxWithConstraintsScope")
@@ -84,7 +84,7 @@ fun SettingsScreen(
                     ) {
                         items(settingsItems.size) { index ->
                             val cardItems = settingsItems[index]
-                            CardContent(
+                            ContenairSettingsItems(
                                 listRowContent = cardItems,
                                 modifier = Modifier.fillMaxWidth()
                             )
@@ -107,32 +107,22 @@ fun SettingsScreen(
                     MyBottomAppBar(navController = navController)
                 }
             ) { paddingValues ->
-                BoxWithConstraints(modifier = Modifier.padding(paddingValues)) {
-                    val columnCount = when {
-                        maxWidth > 1200.dp -> 4// pc/web
-                        maxWidth > 600.dp -> 2//tablette
-                        else -> 1//smartphone
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(1),
+                    modifier = Modifier.fillMaxSize().padding(paddingValues),
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    items(settingsItems.size) { index ->  // Utilisation de .size et index
+                        val cardItems = settingsItems[index]
+                        ContenairSettingsItems(
+                            listRowContent = cardItems,
+                            modifier = Modifier.fillMaxWidth()
+                        )
                     }
-
-                    LazyVerticalGrid(
-                        columns = GridCells.Fixed(columnCount),
-                        modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(16.dp),
-                        verticalArrangement = Arrangement.spacedBy(16.dp),
-                        horizontalArrangement = Arrangement.spacedBy(16.dp)
-                    ) {
-                        items(settingsItems.size) { index ->  // Utilisation de .size et index
-                            val cardItems = settingsItems[index]
-                            CardContent(
-                                listRowContent = cardItems,
-                                modifier = Modifier.fillMaxWidth()
-                            )
-                        }
-                    }
-                    Spacer(modifier = Modifier.height(16.dp))
-
-
                 }
+                Spacer(modifier = Modifier.height(16.dp))
             }
         }
     }

--- a/app/src/main/java/com/example/mealmate/ui/view/settingsScreen/components/ContenairSettingsItems.kt
+++ b/app/src/main/java/com/example/mealmate/ui/view/settingsScreen/components/ContenairSettingsItems.kt
@@ -21,7 +21,7 @@ import com.example.mealmate.ui.view.components.rowIconText.RowContentItem
 import com.example.mealmate.ui.view.components.rowIconText.myList1
 
 @Composable
-fun CardContent(
+fun ContenairSettingsItems(
     listRowContent: List<RowContentItem>,
     modifier: Modifier = Modifier,
     elevation: Dp = 4.dp,
@@ -32,9 +32,7 @@ fun CardContent(
             .fillMaxWidth()
             .padding(horizontal = 10.dp, vertical = 8.dp) // Ajout de padding pour les bords
         ,
-        colors = CardDefaults.cardColors(
-            contentColor = MaterialTheme.colorScheme.onSurface
-        ),
+        colors = CardDefaults.cardColors(contentColor = MaterialTheme.colorScheme.onSurface),
         shape = RoundedCornerShape(10.dp),
         elevation = CardDefaults.cardElevation(defaultElevation = elevation)
     ) {
@@ -62,5 +60,5 @@ fun CardContent(
 @Preview
 @Composable
 private fun CardContentPrev() {
-    CardContent(myList1)
+    ContenairSettingsItems(myList1)
 }

--- a/app/src/main/res/drawable/outward_arrow_icn.xml
+++ b/app/src/main/res/drawable/outward_arrow_icn.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M6,6l0,2l8.59,0l-9.59,9.59l1.41,1.41l9.59,-9.59l0,8.59l2,0l0,-12z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/verified_filled_icn.xml
+++ b/app/src/main/res/drawable/verified_filled_icn.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M23,12l-2.44,-2.79l0.34,-3.69l-3.61,-0.82L15.4,1.5L12,2.96L8.6,1.5L6.71,4.69L3.1,5.5L3.44,9.2L1,12l2.44,2.79l-0.34,3.7l3.61,0.82L8.6,22.5l3.4,-1.47l3.4,1.46l1.89,-3.19l3.61,-0.82l-0.34,-3.69L23,12zM10.09,16.72l-3.8,-3.81l1.48,-1.48l2.32,2.33l5.85,-5.87l1.48,1.48L10.09,16.72z"/>
+    
+</vector>


### PR DESCRIPTION
- Added `NewsItem.kt` composable to display news articles with a title, author, partner image, and news image.
  - Includes functionality to show a full-screen image preview on click.
  - Includes a "MoreVert" icon button that triggers `NewsItemBtmSheet`.
- Created `NewsData.kt` data class for news item properties.
- Added `NewsItemBtmSheet.kt` modal bottom sheet.
  - Provides an option "Lire sur le site officiel" which opens the news article link in a browser.
  - Handles potential errors during link opening.
- Implemented `FullScreenImageView.kt` composable to display an image in full screen with a top app bar for navigation.
- Added `outward_arrow_icn.xml` and `verified_filled_icn.xml` vector drawables.
- Integrated `NewsItem` into `HomeScreen.kt`:
  - Displays a list of `NewsData` items in a `LazyVerticalGrid`.
  - Adjusts column count based on screen width (1 for mobile, 2 for tablet, 4 for PC/web).
- Renamed `CardContent` to `ContenairSettingsItems` in `ContenairSettingsItems.kt` and updated its usage in `SettingsScreen.kt`.
- `SettingsScreen.kt` now uses a fixed `GridCells.Fixed(1)` for its `LazyVerticalGrid`.
- Removed unused `BoxWithConstraints` and column count logic from `DashboardScreen.kt`.
- Added `ShortVibration.kt` composable for haptic feedback (currently unused).
- Minor cleanup in `app/build.gradle.kts`.